### PR TITLE
fix pip dependency syntax

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,4 +22,4 @@ dependencies:
   #  - dgl-cudaXX.X  # Replace XX.X with the version of cudatoolkit installed by 'conda install pytorch -c pytorch -c conda-forge' directly above
   - pip:
       - -e .
-      - -r file:requirements.txt
+      - -r requirements.txt


### PR DESCRIPTION
Recent changes to pip in 21.2.1 have made the `file:requirements.txt` syntax in `environment.yml` no longer work and resolving dependencies fail. Fortunately it's a one line fix.

https://stackoverflow.com/questions/68571543/using-a-pip-requirements-file-in-a-conda-yml-file-throws-attributeerror-fileno
